### PR TITLE
robustness to the DSX example. 

### DIFF
--- a/DSX.ipynb
+++ b/DSX.ipynb
@@ -45,7 +45,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# This cell does some preparatory work to set QISKit up on the IBM Data Science Experience. \n",
@@ -76,19 +78,43 @@
     "home_dir = os.path.expanduser('~')\n",
     "qconfig_filepath = os.path.join(home_dir, 'Qconfig.py') \n",
     "\n",
+    "# TODO: UPDATE the Qconfig template path to point to the main qiskit-tutorials repo.\n",
+    "qconfig_template_path = \"https://raw.githubusercontent.com/jaygambetta/qiskit-tutorial/master/Qconfig.py.template\"\n",
+    "\n",
     "# We need visibility to Qconfig.py module. Add home dir in your sys.path just to be sure. \n",
     "if home_dir not in sys.path:\n",
     "    sys.path.append(home_dir)\n",
-    "\n",
-    "apitoken_str = 'APItoken=\\\"{}\\\"'.format(os.environ[\"IBMQE_API\"])\n",
-    "config_str = \"config = { \\\"url\\\": 'https://quantumexperience.ng.bluemix.net/api'}\"\n",
-    "\n",
-    "with open(qconfig_filepath, 'w') as fil:\n",
-    "    fil.write(apitoken_str + \"\\n\")\n",
-    "    fil.write(config_str + \"\\n\")\n",
-    "\n",
-    "# Test creation of Qconfig file\n",
-    "import Qconfig"
+    "    \n",
+    "# First check if the Qconfig module has already been loaded (may happen if you are executing this cell more than once)\n",
+    "if 'Qconfig' in sys.modules:\n",
+    "    # The module has been imported already. Reload it to make sure we get the latest API token\n",
+    "    try:\n",
+    "        importlib.reload(Qconfig)\n",
+    "        Qconfig.update_token(os.environ[\"IBMQE_API\"])\n",
+    "    except AttributeError:\n",
+    "        print(\"Qconfig reload failed. This could be due to missing Qconfig.py file.\")\n",
+    "        print(\"Try restarting the Jupyter notebook kernel!\")\n",
+    "        raise\n",
+    "    except AssertionError:\n",
+    "        print(\"Have you set a valid APItoken?\")\n",
+    "        raise\n",
+    "    except:\n",
+    "        print(\"Qconfig reload or API token update failed.\")\n",
+    "        print(\"Try updating the token and restarting the Jupyter notebook kernel\")\n",
+    "        raise \n",
+    "else:\n",
+    "    # Try importing Qconfig module. If it doesn't exist, then download it from the qiskit-tutorials repo. \n",
+    "    try:\n",
+    "        import Qconfig\n",
+    "    except ImportError:\n",
+    "        urllib.request.urlretrieve (\"{}\".format(qconfig_template_path), \"{}\".format(qconfig_filepath))\n",
+    "        # chmod the file. For Python 3, need to prefix the permission with 0o (zero and character small oh)\n",
+    "        os.chmod(qconfig_filepath , 0o664)\n",
+    "        import Qconfig\n",
+    "    except:\n",
+    "        print(\"Unexpected error!\")\n",
+    "        raise\n",
+    "            "
    ]
   },
   {
@@ -103,7 +129,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Trivial program to test if the QISKit setup was sucessful.\n",
@@ -159,14 +187,20 @@
     "if home_dir not in sys.path:\n",
     "    sys.path.append(home_dir)\n",
     "\n",
-    "import Qconfig"
+    "import Qconfig\n",
+    "\n",
+    "# NOTE:\n",
+    "# If you ever change the value of environment variable  os.environ[\"IBMQE_API\"] AFTER executing this cell, \n",
+    "# you can call the following code to update its value. \n",
+    "# Qconfig.update_token(os.environ[\"IBMQE_API\"])    \n",
+    "# Or just set it as : Qconfig.APItoken = os.environ[\"IBMQE_API\"] \n"
    ]
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -180,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
made the DSX example more robust. 

_Changes:_  Safely import or reload Qconfig or even get this module from qiskit repo if the file is missing. This code also ensures that upto date value for  APItoken is set even when the Qconfig module is already imported. This uses the code in the new  `Qconfig.py.template` file.

@rraymondhp @attp 