### PR TITLE
Adding simple compiling and running example to backend tutorial.

### DIFF
--- a/reference/tools/working_with_backends.ipynb
+++ b/reference/tools/working_with_backends.ipynb
@@ -4,50 +4,49 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"../images/QISKit-c.gif\" alt=\"Note: In order for images to show up in this jupyter notebook you need to select File => Trusted Notebook\" width=\"250 px\" align=\"left\">"
+    "<img src=\"../../images/QISKit.gif\" alt=\"Note: In order for images to show up in this jupyter notebook you need to select File => Trusted Notebook\" width=\"250 px\" align=\"left\">"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## _*Working with the different backends*_ \n",
+    "# _*Working with Different Backends*_ \n",
+    "\n",
+    "In this tutorial, we will first describe the various [backends](#backends) available in QISKit and how to find out more information about each of them, then we will explore how QISKit allows you to [compile and run](#compile) the same quantum circuit on different backends with different connectivities. \n",
     "\n",
     "The latest version of this notebook is available on https://github.com/QISKit/qiskit-tutorial.\n",
     "\n",
     "***\n",
     "### Contributors\n",
-    "Jay Gambetta and Joe Hellmers"
+    "Jay Gambetta, Joe Hellmers, Anna Phan"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## The backend. \n",
+    "## The Backends<a id='backends'></a>\n",
     "\n",
-    "At the core of QISKit is the ability to access different backends to run your quantum programs. These backends are real devices, online simulators, and local simulations. As we continue to increase the flexibility of QISKit we expect there to be many different backends. \n",
+    "At the core of QISKit is the ability to access different backends to run your quantum programs. These backends are real devices, online simulators, and local simulations. As we continue to increase the flexibility of QISKit we expect there to be many different backends. These will include new hardware with different number of qubits, connectivity, different gate sets, and simulators with different properties. \n",
     "\n",
-    "These include new hardware with different number of qubits, connectivity, different gate sets, and simulators with different properties. \n",
-    "\n",
-    "Current hardware \n",
+    "Current devices: \n",
     "* [IBMQX2](https://github.com/IBM/qiskit-qx-info/tree/master/backends/ibmqx2) - a 5 qubit transmon bowtie chip.\n",
     "* [IBMQX4](https://github.com/IBM/qiskit-qx-info/tree/master/backends/ibmqx4) - a 5 qubit transmon bowtie chip.\n",
     "* [IBMQX5](https://github.com/IBM/qiskit-qx-info/tree/master/backends/ibmqx5) - a 16 qubit ladder chip.\n",
     "\n",
-    "Current simulators \n",
-    "\n",
-    "* QASM simulator – simulates a quantum circuit and predicts the outcomes of a quantum experiment (samples over many shots).\n",
-    "* QASM simulators with noise – simulates a quantum circuit with additional noise inputs.\n",
-    "* Unitary simulator – predicts the unitary of a quantum circuit (ignoring measurement and if operations)."
+    "Current simulators:\n",
+    "* QASM simulators - these simulate a quantum circuit and predict the outcomes of a quantum experiment.\n",
+    "    * Online QASM simulator – this runs online and can be used for up to 20 qubits with conditionals. \n",
+    "    * Online HPC QASM simulator – this runs online and can be used for up to 32 qubits without conditionals. \n",
+    "    * Local QASM simulator - this runs on your local machine, and should only be used for less than 10 qubits. \n",
+    "* Local unitary simulator – predicts the unitary of a quantum circuit, ignoring measurement and conditional operations."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Checking the version of PYTHON; we only support > 3.5\n",
@@ -57,9 +56,12 @@
     "    \n",
     "from pprint import pprint\n",
     "\n",
-    "# importing the QISKit\n",
+    "# import QISKit\n",
     "from qiskit import QuantumProgram\n",
-    "import Qconfig"
+    "import Qconfig\n",
+    "\n",
+    "# import basic plotting tools\n",
+    "from qiskit.tools.visualization import plot_histogram"
    ]
   },
   {
@@ -80,24 +82,21 @@
    "source": [
     "### List and status \n",
     "\n",
-    "To list all the backends that are avaiable for use we have provided the command \n",
-    "\n",
-    "```Q_program.available_backends()```"
+    "To list all the backends that can be used we have provided the command: `Q_program.available_backends()`"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['ibmqx4',\n",
-      " 'ibmqx5',\n",
+      "['ibmqx5',\n",
+      " 'ibmqx4',\n",
+      " 'ibmqx_hpc_qasm_simulator',\n",
       " 'ibmqx2',\n",
       " 'ibmqx_qasm_simulator',\n",
       " 'local_qasm_simulator',\n",
@@ -113,37 +112,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The status can be obtained using \n",
-    "\n",
-    "```Q_program.get_backend_status('ibmqx4')```"
+    "The status can be obtained using the function `Q_program.get_backend_status()`:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'available': True, 'backend': 'ibmqx4', 'busy': False, 'pending_jobs': 0}\n"
+      "{'available': True, 'busy': False, 'pending_jobs': 46}\n"
      ]
     }
    ],
    "source": [
-    "pprint(Q_program.get_backend_status('ibmqx4'))"
+    "pprint(Q_program.get_backend_status('ibmqx5'))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If the backend system is under maintenance it will be listed as unavailable\n",
-    "\n",
-    "```Q_program.get_backend_status('ibmqx2')```"
+    "If the backend system is under maintenance it will be listed as unavailable:"
    ]
   },
   {
@@ -155,7 +148,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'available': False, 'backend': 'ibmqx2', 'busy': False, 'pending_jobs': 2456}\n"
+      "{'available': True, 'busy': False, 'pending_jobs': 0}\n"
      ]
     }
    ],
@@ -169,9 +162,17 @@
    "source": [
     "### Configuration\n",
     "\n",
-    "To get more informaiton about the backend \n",
-    "\n",
-    "```Q_program.get_backend_configuration('ibmqx4')```"
+    "To get more information about a backend use this function: `Q_program.get_backend_configuration()`. This will return a subset of the following information, depending on backend: \n",
+    "- `name` - backend name\n",
+    "- `description` - human readable description of the backend\n",
+    "- `simulator` - flag for labeling if the backend is simulator or not\n",
+    "- `n_qubits` - number of qubits in the backend\n",
+    "- `coupling_map` - device connectivity map where `i:[j]` represents that control qubit `i` is connected to target qubit(s) `j`\n",
+    "- `basis_gates` - gate set of the backend\n",
+    "- `online_date` - date the backend went online\n",
+    "- `chip_name` - code name for the backend\n",
+    "- `url` - url address to find more information about the backend\n",
+    "- `version` - version number that will iterate when changes are made to the backend"
    ]
   },
   {
@@ -183,50 +184,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'basis_gates': 'SU2+CNOT',\n",
-      " 'chip_name': 'Raven',\n",
-      " 'coupling_map': {1: [0], 2: [0, 1, 4], 3: [2, 4]},\n",
-      " 'description': '5 qubit transmon bowtie chip 3',\n",
+      "{'basis_gates': 'u1,u2,u3,cx,id',\n",
+      " 'chip_name': 'Sparrow',\n",
+      " 'coupling_map': {0: [1, 2], 1: [2], 3: [2, 4], 4: [2]},\n",
+      " 'description': '5 transmon bowtie',\n",
       " 'n_qubits': 5,\n",
-      " 'name': 'ibmqx4',\n",
-      " 'online_date': '2017-09-18T11:00:00.000Z',\n",
+      " 'name': 'ibmqx2',\n",
+      " 'online_date': '2017-01-10T12:00:00.000Z',\n",
       " 'simulator': False,\n",
-      " 'url': 'https://ibm.biz/qiskit-ibmqx4',\n",
+      " 'url': 'https://ibm.biz/qiskit-ibmqx2',\n",
       " 'version': '1'}\n"
      ]
     }
    ],
    "source": [
-    "pprint(Q_program.get_backend_configuration('ibmqx4'))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This information for hardware contains \n",
-    "    - 'name': 'backend_name',    \n",
-    "        Backend name used to run quantum programs\n",
-    "    - 'version': '1',    \n",
-    "        A version number that will iterate when changes are made to the device\n",
-    "    - 'url': 'https://ibm.biz/qiskit-ibmqx4',    \n",
-    "        A url address to find more information about the device\n",
-    "    - 'simulator': false,    \n",
-    "        Flag for labeling if the backend is simulator or not\n",
-    "    - 'description': '5 qubit transmon bowtie chip 3',   \n",
-    "        A human readable description of the device\n",
-    "    - 'n_qubits': 5,    \n",
-    "        The number of qubits in the device\n",
-    "    - 'coupling_map': {1: [0], 2: [0, 1, 4], 3: [2, 4]},    \n",
-    "        The connectivity map of the deive i:[j] represents control qubit i coupled to target qubit(s) j\n",
-    "    - 'basis_gates': 'SU2+CNOT',    \n",
-    "        The gate set of the device is the complete set SU(2) gate operations and the controlled NOT gate\n",
-    "    - 'online_date': '2017-09-18',\n",
-    "        The date the device went online\n",
-    "    - 'chip_name': 'Raven'\n",
-    "        A code name for the device\n",
-    "        \n",
-    "The information for the simulators is obtained using the same command"
+    "pprint(Q_program.get_backend_configuration('ibmqx2'))"
    ]
   },
   {
@@ -255,31 +227,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This information for a simulator contains \n",
-    "    - 'name': 'backend_name',    \n",
-    "        Backend name used to run quantum programs\n",
-    "    - 'url': 'https://github.com/IBM/qiskit-sdk-py',    \n",
-    "        A url address to find more information about the simulator\n",
-    "    - 'simulator': true,    \n",
-    "        Flag for labeling if the backend is simulator or not\n",
-    "    - 'description': 'A python simulator for qasm files',   \n",
-    "        A human readable description of the simulator\n",
-    "    - 'coupling_map': 'all-to-all',    \n",
-    "        The connectivity map, all-to-all means that every two qubit gate is possible \n",
-    "    - 'basis_gates': 'u1,u2,u3,cx,id',    \n",
-    "        The gate set of the device. Here u1, u2, an u3 are single qubit unitary rotations on the qubits, cx is the \n",
-    "        CNOT gate, and id is the identity operation"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Extra information - calibrations\n",
+    "### Additional Device Information\n",
     "\n",
-    "For the online devices calibrations are run every 12 hours and the last calibration data can be obtained using \n",
-    "\n",
-    "```Q_program.get_backend_calibration('ibmqx4')```"
+    "For the devices, you can find out lots more information, such as parameter and calibration data using `Q_program.get_backend_calibration()` and `Q_program.get_backend_parameters()`:"
    ]
   },
   {
@@ -291,74 +241,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'backend': 'ibmqx4',\n",
-      " 'last_update_date': '2017-10-31T11:02:35.000Z',\n",
-      " 'multi_qubit_gates': [{'gateError': {'date': '2017-10-31T11:02:35Z',\n",
-      "                                      'value': 0.021623279195603723},\n",
-      "                        'name': 'CX1_0',\n",
-      "                        'qubits': [1, 0],\n",
-      "                        'type': 'CX'},\n",
-      "                       {'gateError': {'date': '2017-10-31T11:02:35Z',\n",
-      "                                      'value': 0.018312238448853407},\n",
-      "                        'name': 'CX2_0',\n",
-      "                        'qubits': [2, 0],\n",
-      "                        'type': 'CX'},\n",
-      "                       {'gateError': {'date': '2017-10-31T11:02:35Z',\n",
-      "                                      'value': 0.02568789465394103},\n",
-      "                        'name': 'CX2_1',\n",
-      "                        'qubits': [2, 1],\n",
-      "                        'type': 'CX'},\n",
-      "                       {'gateError': {'date': '2017-10-31T11:02:35Z',\n",
-      "                                      'value': 0.038361464669008916},\n",
-      "                        'name': 'CX2_4',\n",
-      "                        'qubits': [2, 4],\n",
-      "                        'type': 'CX'},\n",
-      "                       {'gateError': {'date': '2017-10-31T11:02:35Z',\n",
-      "                                      'value': 0.023654165328270943},\n",
-      "                        'name': 'CX3_2',\n",
-      "                        'qubits': [3, 2],\n",
-      "                        'type': 'CX'},\n",
-      "                       {'gateError': {'date': '2017-10-31T11:02:35Z',\n",
-      "                                      'value': 0.03494356811648844},\n",
-      "                        'name': 'CX3_4',\n",
-      "                        'qubits': [3, 4],\n",
-      "                        'type': 'CX'}],\n",
-      " 'qubits': [{'gateError': {'date': '2017-10-31T11:02:35Z',\n",
-      "                           'value': 0.000858490762927322},\n",
-      "             'name': 'Q0',\n",
-      "             'readoutError': {'date': '2017-10-31T11:02:35Z', 'value': 0.042}},\n",
-      "            {'gateError': {'date': '2017-10-31T11:02:35Z',\n",
-      "                           'value': 0.0012019552727863259},\n",
-      "             'name': 'Q1',\n",
-      "             'readoutError': {'date': '2017-10-31T11:02:35Z', 'value': 0.062}},\n",
-      "            {'gateError': {'date': '2017-10-31T11:02:35Z',\n",
-      "                           'value': 0.0013737021608475342},\n",
-      "             'name': 'Q2',\n",
-      "             'readoutError': {'date': '2017-10-31T11:02:35Z', 'value': 0.029}},\n",
-      "            {'gateError': {'date': '2017-10-31T11:02:35Z',\n",
-      "                           'value': 0.0021466840188233416},\n",
-      "             'name': 'Q3',\n",
-      "             'readoutError': {'date': '2017-10-31T11:02:35Z', 'value': 0.074}},\n",
-      "            {'gateError': {'date': '2017-10-31T11:02:35Z',\n",
-      "                           'value': 0.0036932423737144893},\n",
-      "             'name': 'Q4',\n",
-      "             'readoutError': {'date': '2017-10-31T11:02:35Z', 'value': 0.07}}]}\n"
+      "{'last_update_date': '2018-03-12T11:38:29.000Z', 'qubits': [{'gateError': {'date': '2018-03-12T11:38:29Z', 'value': 0.000858490762927322}, 'name': 'Q0', 'readoutError': {'date': '2018-03-12T11:38:29Z', 'value': 0.046}}, {'gateError': {'date': '2018-03-12T11:38:29Z', 'value': 0.0006867731322012238}, 'name': 'Q1', 'readoutError': {'date': '2018-03-12T11:38:29Z', 'value': 0.054}}, {'gateError': {'date': '2018-03-12T11:38:29Z', 'value': 0.00197489316929661}, 'name': 'Q2', 'readoutError': {'date': '2018-03-12T11:38:29Z', 'value': 0.128}}, {'gateError': {'date': '2018-03-12T11:38:29Z', 'value': 0.00197489316929661}, 'name': 'Q3', 'readoutError': {'date': '2018-03-12T11:38:29Z', 'value': 0.087}}, {'gateError': {'date': '2018-03-12T11:38:29Z', 'value': 0.001803112096824766}, 'name': 'Q4', 'readoutError': {'date': '2018-03-12T11:38:29Z', 'value': 0.045}}], 'multi_qubit_gates': [{'qubits': [1, 0], 'type': 'CX', 'gateError': {'date': '2018-03-12T11:38:29Z', 'value': 0.019933034541237543}, 'name': 'CX1_0'}, {'qubits': [2, 0], 'type': 'CX', 'gateError': {'date': '2018-03-12T11:38:29Z', 'value': 0.024806261843678845}, 'name': 'CX2_0'}, {'qubits': [2, 1], 'type': 'CX', 'gateError': {'date': '2018-03-12T11:38:29Z', 'value': 0.0584889238863901}, 'name': 'CX2_1'}, {'qubits': [2, 4], 'type': 'CX', 'gateError': {'date': '2018-03-12T11:38:29Z', 'value': 0.06398473494573023}, 'name': 'CX2_4'}, {'qubits': [3, 2], 'type': 'CX', 'gateError': {'date': '2018-03-12T11:38:29Z', 'value': 0.02677371835866532}, 'name': 'CX3_2'}, {'qubits': [3, 4], 'type': 'CX', 'gateError': {'date': '2018-03-12T11:38:29Z', 'value': 0.0248740607207448}, 'name': 'CX3_4'}], 'backend': 'ibmqx4'}\n"
      ]
     }
    ],
    "source": [
-    "pprint(Q_program.get_backend_calibration('ibmqx4'))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Extra information - parameters \n",
-    "\n",
-    "For the online devices there are extra parameters such as gate times, coherence times, etc  which can be obtained using \n",
-    "\n",
-    "```Q_program.get_backend_parameters('ibmqx4')```"
+    "print(Q_program.get_backend_calibration('ibmqx4'))"
    ]
   },
   {
@@ -370,118 +258,157 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'backend': 'ibmqx4',\n",
-      " 'fridge_parameters': {'Temperature': {'date': '2017-10-31T11:02:35Z',\n",
-      "                                       'unit': 'K',\n",
-      "                                       'value': 0.021},\n",
-      "                       'cooldownDate': '2017-09-07'},\n",
-      " 'last_update_date': '2017-10-31T11:02:35.000Z',\n",
-      " 'qubits': [{'T1': {'date': '2017-10-31T11:02:35Z', 'unit': 'µs', 'value': 42},\n",
-      "             'T2': {'date': '2017-10-31T11:02:35Z',\n",
-      "                    'unit': 'µs',\n",
-      "                    'value': 32.8},\n",
-      "             'buffer': {'date': '2017-10-31T11:02:35Z',\n",
-      "                        'unit': 'ns',\n",
-      "                        'value': 10},\n",
-      "             'frequency': {'date': '2017-10-31T11:02:35Z',\n",
-      "                           'unit': 'GHz',\n",
-      "                           'value': 5.24614},\n",
-      "             'gateTime': {'date': '2017-10-31T11:02:35Z',\n",
-      "                          'unit': 'ns',\n",
-      "                          'value': 50},\n",
-      "             'name': 'Q0'},\n",
-      "            {'T1': {'date': '2017-10-31T11:02:35Z',\n",
-      "                    'unit': 'µs',\n",
-      "                    'value': 60.4},\n",
-      "             'T2': {'date': '2017-10-31T11:02:35Z',\n",
-      "                    'unit': 'µs',\n",
-      "                    'value': 45.1},\n",
-      "             'buffer': {'date': '2017-10-31T11:02:35Z',\n",
-      "                        'unit': 'ns',\n",
-      "                        'value': 10},\n",
-      "             'frequency': {'date': '2017-10-31T11:02:35Z',\n",
-      "                           'unit': 'GHz',\n",
-      "                           'value': 5.30262},\n",
-      "             'gateTime': {'date': '2017-10-31T11:02:35Z',\n",
-      "                          'unit': 'ns',\n",
-      "                          'value': 50},\n",
-      "             'name': 'Q1'},\n",
-      "            {'T1': {'date': '2017-10-31T11:02:35Z',\n",
-      "                    'unit': 'µs',\n",
-      "                    'value': 47.4},\n",
-      "             'T2': {'date': '2017-10-31T11:02:35Z',\n",
-      "                    'unit': 'µs',\n",
-      "                    'value': 51.3},\n",
-      "             'buffer': {'date': '2017-10-31T11:02:35Z',\n",
-      "                        'unit': 'ns',\n",
-      "                        'value': 10},\n",
-      "             'frequency': {'date': '2017-10-31T11:02:35Z',\n",
-      "                           'unit': 'GHz',\n",
-      "                           'value': 5.35621},\n",
-      "             'gateTime': {'date': '2017-10-31T11:02:35Z',\n",
-      "                          'unit': 'ns',\n",
-      "                          'value': 50},\n",
-      "             'name': 'Q2'},\n",
-      "            {'T1': {'date': '2017-10-31T11:02:35Z',\n",
-      "                    'unit': 'µs',\n",
-      "                    'value': 33.4},\n",
-      "             'T2': {'date': '2017-10-31T11:02:35Z',\n",
-      "                    'unit': 'µs',\n",
-      "                    'value': 30.1},\n",
-      "             'buffer': {'date': '2017-10-31T11:02:35Z',\n",
-      "                        'unit': 'ns',\n",
-      "                        'value': 10},\n",
-      "             'frequency': {'date': '2017-10-31T11:02:35Z',\n",
-      "                           'unit': 'GHz',\n",
-      "                           'value': 5.43174},\n",
-      "             'gateTime': {'date': '2017-10-31T11:02:35Z',\n",
-      "                          'unit': 'ns',\n",
-      "                          'value': 50},\n",
-      "             'name': 'Q3'},\n",
-      "            {'T1': {'date': '2017-10-31T11:02:35Z',\n",
-      "                    'unit': 'µs',\n",
-      "                    'value': 56.9},\n",
-      "             'T2': {'date': '2017-10-31T11:02:35Z',\n",
-      "                    'unit': 'µs',\n",
-      "                    'value': 22.9},\n",
-      "             'buffer': {'date': '2017-10-31T11:02:35Z',\n",
-      "                        'unit': 'ns',\n",
-      "                        'value': 10},\n",
-      "             'frequency': {'date': '2017-10-31T11:02:35Z',\n",
-      "                           'unit': 'GHz',\n",
-      "                           'value': 5.18248},\n",
-      "             'gateTime': {'date': '2017-10-31T11:02:35Z',\n",
-      "                          'unit': 'ns',\n",
-      "                          'value': 50},\n",
-      "             'name': 'Q4'}]}\n"
+      "{'last_update_date': '2018-03-12T11:38:29.000Z', 'fridge_parameters': {'cooldownDate': '2017-09-07', 'Temperature': {'date': '2018-03-12T11:38:29Z', 'value': 0.021, 'unit': 'K'}}, 'qubits': [{'name': 'Q0', 'buffer': {'date': '2018-03-12T11:38:29Z', 'value': 10, 'unit': 'ns'}, 'gateTime': {'date': '2018-03-12T11:38:29Z', 'value': 50, 'unit': 'ns'}, 'T2': {'date': '2018-03-12T11:38:29Z', 'value': 35.4, 'unit': 'µs'}, 'T1': {'date': '2018-03-12T11:38:29Z', 'value': 55.4, 'unit': 'µs'}, 'frequency': {'date': '2018-03-12T11:38:29Z', 'value': 5.24466, 'unit': 'GHz'}}, {'name': 'Q1', 'buffer': {'date': '2018-03-12T11:38:29Z', 'value': 10, 'unit': 'ns'}, 'gateTime': {'date': '2018-03-12T11:38:29Z', 'value': 50, 'unit': 'ns'}, 'T2': {'date': '2018-03-12T11:38:29Z', 'value': 61.7, 'unit': 'µs'}, 'T1': {'date': '2018-03-12T11:38:29Z', 'value': 55.3, 'unit': 'µs'}, 'frequency': {'date': '2018-03-12T11:38:29Z', 'value': 5.30492, 'unit': 'GHz'}}, {'name': 'Q2', 'buffer': {'date': '2018-03-12T11:38:29Z', 'value': 10, 'unit': 'ns'}, 'gateTime': {'date': '2018-03-12T11:38:29Z', 'value': 50, 'unit': 'ns'}, 'T2': {'date': '2018-03-12T11:38:29Z', 'value': 38, 'unit': 'µs'}, 'T1': {'date': '2018-03-12T11:38:29Z', 'value': 39.3, 'unit': 'µs'}, 'frequency': {'date': '2018-03-12T11:38:29Z', 'value': 5.35192, 'unit': 'GHz'}}, {'name': 'Q3', 'buffer': {'date': '2018-03-12T11:38:29Z', 'value': 10, 'unit': 'ns'}, 'gateTime': {'date': '2018-03-12T11:38:29Z', 'value': 50, 'unit': 'ns'}, 'T2': {'date': '2018-03-12T11:38:29Z', 'value': 12.6, 'unit': 'µs'}, 'T1': {'date': '2018-03-12T11:38:29Z', 'value': 47.6, 'unit': 'µs'}, 'frequency': {'date': '2018-03-12T11:38:29Z', 'value': 5.43031, 'unit': 'GHz'}}, {'name': 'Q4', 'buffer': {'date': '2018-03-12T11:38:29Z', 'value': 10, 'unit': 'ns'}, 'gateTime': {'date': '2018-03-12T11:38:29Z', 'value': 50, 'unit': 'ns'}, 'T2': {'date': '2018-03-12T11:38:29Z', 'value': 32.1, 'unit': 'µs'}, 'T1': {'date': '2018-03-12T11:38:29Z', 'value': 58.7, 'unit': 'µs'}, 'frequency': {'date': '2018-03-12T11:38:29Z', 'value': 5.18388, 'unit': 'GHz'}}], 'backend': 'ibmqx4'}\n"
      ]
     }
    ],
    "source": [
-    "pprint(Q_program.get_backend_parameters('ibmqx4'))"
+    "print(Q_program.get_backend_parameters('ibmqx4'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compiling and Running on Different Devices <a id='compile'></a>\n",
+    "\n",
+    "Each of the hardware devices has a different configuration, in terms of number of qubits and their connectivity. For example, even though both `ibmqx2` and `ibmqx4` have 5 qubits in a `bowtie` layout, their connectivity, in terms of what `CNOT` gates are available, is different. This means that circuits written for one device may not run on another device without modification. \n",
+    "\n",
+    "In QISKit, we provide a `compile` function to rewrite circuits so they can be run with a particular configuration. This is done through specifying a `coupling map`. Let's go through a simple example of creating an entangled Bell state on `ibmqx2`, then on `ibmqx4` using qubits `0` and `1`. More information about the `compile` function with a more complex example can be found in the [appendix](../../appendix/advanced_qiskit/compiling_and_running.ipynb).\n",
+    "\n",
+    "First let's write the code for creating this state and measuring it, using a `CNOT` from qubit `0` to qubit `1`, and look at the created QASM:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OPENQASM 2.0;\n",
+      "include \"qelib1.inc\";\n",
+      "qreg q2[2];\n",
+      "creg c2[2];\n",
+      "h q2[0];\n",
+      "cx q2[0],q2[1];\n",
+      "measure q2[0] -> c2[0];\n",
+      "measure q2[1] -> c2[1];\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Creating registers\n",
+    "q2 = Q_program.create_quantum_register(\"q2\", 2)\n",
+    "c2 = Q_program.create_classical_register(\"c2\", 2)\n",
+    "\n",
+    "# quantum circuit to make an entangled state \n",
+    "bell = Q_program.create_circuit(\"bell\", [q2], [c2])\n",
+    "bell.h(q2[0])\n",
+    "bell.cx(q2[0], q2[1])\n",
+    "bell.measure(q2[0], c2[0])\n",
+    "bell.measure(q2[1], c2[1])\n",
+    "print(Q_program.get_qasm('bell'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's get the coupling map for `ibmqx2`, compile the circuit to run on that device and look at the created QASM:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OPENQASM 2.0;\n",
+      "include \"qelib1.inc\";\n",
+      "qreg q[2];\n",
+      "creg c2[2];\n",
+      "u2(0.0,3.141592653589793) q[0];\n",
+      "cx q[0],q[1];\n",
+      "measure q[1] -> c2[1];\n",
+      "measure q[0] -> c2[0];\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "ibmqx2_backend = Q_program.get_backend_configuration('ibmqx2')\n",
+    "ibmqx2_coupling = ibmqx2_backend['coupling_map']\n",
+    "\n",
+    "compile_ibmqx2 = Q_program.compile(['bell'], backend='ibmqx2', coupling_map=ibmqx2_coupling)\n",
+    "print(Q_program.get_compiled_qasm(compile_ibmqx2, 'bell'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that while the `compile` function has replaced the `h` gate with an equivalent `u2` gate, it hasn't changed anything else. This is because a `CNOT` from qubit `0` to qubit `1` is possible on `ibmqx2`.\n",
+    "\n",
+    "Now let's get the coupling map for `ibmqx4`, compile the circuit to run on that device and look at the created QASM:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OPENQASM 2.0;\n",
+      "include \"qelib1.inc\";\n",
+      "qreg q[2];\n",
+      "creg c2[2];\n",
+      "u2(0.0,3.141592653589793) q[1];\n",
+      "cx q[1],q[0];\n",
+      "measure q[0] -> c2[1];\n",
+      "measure q[1] -> c2[0];\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "ibmqx4_backend = Q_program.get_backend_configuration('ibmqx4')\n",
+    "ibmqx4_coupling = ibmqx4_backend['coupling_map']\n",
+    "\n",
+    "compile_ibmqx4 = Q_program.compile(['bell'], backend='ibmqx4', coupling_map=ibmqx4_coupling)\n",
+    "print(Q_program.get_compiled_qasm(compile_ibmqx4, 'bell'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note this time the `compile` function ended with a final circuit containing a `h` gate on qubit `1` and a `CNOT` from qubit `1` to qubit `0` to create an equivalent entangled bell state.\n",
+    "\n",
+    "This `compile` functionality also exists in the `execute` function, where you can specify a `coupling_map`, and your circuit will be modified for that configuration, then executed on the specified backend. \n",
+    "\n",
+    "Below is the same circuit compiled using different configurations, but run on the local simulator backend. Try running them yourself on the devices (checking that they are available first)!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<h2>Version information</h2>\n",
-       "<p>Please note that this tutorial is targeted to the <b>stable</b> version of the QISKit SDK. The following versions of the packages are recommended:</p>\n",
-       "<table>\n",
-       "<tr><th>Package</th><th colspan=\"2\">Version</th></tr>\n",
-       "<tr><td>QISKit</td><td> 0.4.8</td></tr>\n",
-       "<tr><td>IBMQuantumExperience</td><td>&gt;= 1.8.26</td></tr>\n",
-       "<tr><td>numpy</td><td>&gt;= 1.13, &lt; 1.14</td></tr>\n",
-       "<tr><td>scipy</td><td>&gt;= 0.19, &lt; 0.20</td></tr>\n",
-       "<tr><td>matplotlib</td><td>&gt;= 2.0, &lt; 2.1</td></tr>\n",
-       "</table>"
-      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAEFCAYAAAD5bXAgAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAGhRJREFUeJzt3XuQVeW55/HvQ7cYQzR6FKMBUTiABhCItuIxqZibXPRE\nTMwo0YlRkyCJxjgpLyQZUzPJiYmTM4mMIEQzjpfJiMYblAcxOSonWmhxMWJoLBDRCMQrBO+KDc/8\nsTedplnQvaF77wa+n6ou1nrXu/d6emv3r9da73pXZCaSJLXWrdYFSJK6JgNCklTIgJAkFTIgJEmF\nDAhJUiEDQpJUyICQJBWqWkBExOiIWBoRyyNi4lb6fDoinoiIxoj4j2rVJknaUlTjRrmIqAOWAScC\nq4D5wFcyc0mLPvsCc4HRmfl8RByYmS93enGSpELVOoI4FliemSsycz0wHRjbqs+ZwF2Z+TyA4SBJ\ntVVfpf30Ala2WF8FjGjVZyCwR0TMAfYGJmXmzdt60wMOOCAPO+ywDixTknZ9CxcufDUze7bVr1oB\n0R71wNHA54C9gEcj4rHMXNayU0SMB8YD9OnThwULFlS9UEnamUXEX9rTr1qnmFYDh7RY711ua2kV\ncH9mvpWZrwJ/BIa1fqPMvC4zGzKzoWfPNgNQkrSdqhUQ84EBEdE3IroD44CZrfrMAD4ZEfUR8UFK\np6CeqlJ9kqRWqnKKKTObIuJC4H6gDrghMxsjYkJ5+7TMfCoiZgNPAhuB32Tm4mrUJ0naUlWGuXaW\nhoaG9BqEJFUmIhZmZkNb/byTWpJUyICQJBUyICRJhQwISVIhA0KSVMiAkCQVMiAkSYUMCElSIQNC\nklTIgJAkFTIgJEmFDAhJO7XZs2dz+OGH079/f37+859vsX3OnDl8+MMfZvjw4QwfPpwf//jHbb72\niiuuYOjQoQwfPpyRI0fy17/+FYD169dz7rnncuSRRzJs2DDmzJnT/JqFCxdy5JFH0r9/fy666CJa\nznN3++23M2jQIAYPHsyZZ57ZCZ9CJ8nMnfbr6KOPTkm7r6ampuzXr18+88wz+d577+XQoUOzsbFx\nsz4PPfRQnnzyyRW99rXXXmvuN2nSpDz//PMzM3Py5Ml5zjnnZGbmSy+9lEcddVRu2LAhMzOPOeaY\nfPTRR3Pjxo05evTonDVrVmZmLlu2LIcPH55r165tfl2tAQuyHb9jPYKQtNOaN28e/fv3p1+/fnTv\n3p1x48YxY8aMHX7tPvvs09zvrbfeIiIAWLJkCZ/97GcBOPDAA9l3331ZsGABL7zwAq+//jrHHXcc\nEcHZZ5/NPffcA8D111/PBRdcwH777df8up2FAbGD2jq83WT+/PnU19dzxx13NLdNmjSJIUOGMHjw\nYK6++urN+l9zzTUcccQRDB48mMsuu6y5/Wc/+xn9+/fn8MMP5/77729uv+222xg6dCiDBw/m8ssv\n32L/d955JxHhI1q1S1m9ejWHHPL3h1X27t2b1atbP6wS5s6dy9ChQxkzZgyNjY3teu0Pf/hDDjnk\nEH772982n5YaNmwYM2fOpKmpiWeffZaFCxeycuVKVq9eTe/evQvfa9myZSxbtoxPfOITHHfcccye\nPbtjP4ROZEDsgA0bNnDBBRdw3333sWTJEm699VaWLFlS2O/yyy9n5MiRzW2LFy/m+uuvZ968eSxa\ntIh7772X5cuXA/DQQw8xY8YMFi1aRGNjI5dccglQ+utl+vTpNDY2Mnv2bL797W+zYcMG1qxZw6WX\nXsoDDzxAY2MjL774Ig888EDzvt544w0mTZrEiBEjOvkTkbqeo446iueff54nn3yS73znO5x66qnt\net1Pf/pTVq5cyVlnncXkyZMBOO+88+jduzcNDQ1cfPHFHH/88dTV1W3zfZqamnj66aeZM2cOt956\nK9/85jdZt27dDn9f1WBA7ID2Ht5ec801nHbaaZsdWj711FOMGDGCD37wg9TX13PCCSdw1113ATB1\n6lQmTpzInnvuCfz9kHTGjBmMGzeOPffck759+9K/f3/mzZvHihUrGDBgAJue0f35z3+eO++8s3lf\nV1xxBZdffjkf+MAHOu2zkGqhV69erFy5snl91apV9OrVa7M+++yzDx/60IcAOOmkk3j//fd59dVX\n2/VagLPOOqv556m+vp5f/epXPPHEE8yYMYN169YxcOBAevXqxapVqwrfq3fv3pxyyinsscce9O3b\nl4EDB/L000933IfQiQyIHdCew9vVq1dz9913861vfWuz9iFDhvDwww+zZs0a3n77bWbNmtX8P+uy\nZct4+OGHGTFiBCeccALz58/f5v769+/P0qVLee6552hqauKee+5pfq/HH3+clStXcvLJJ3fKZyDV\n0jHHHMPTTz/Ns88+y/r165k+fTqnnHLKZn1efPHF5hFF8+bNY+PGjey///7bfG3LX+AzZszgiCOO\nAODtt9/mrbfeAuAPf/gD9fX1DBo0iIMPPph99tmHxx57jMzk5ptvZuzYsQCceuqpzaOdXn31VZYt\nW0a/fv069XPpKFV5JvXu7OKLL+aqq66iW7fNs/hjH/tY82mnHj16MHz48OZD1aamJtauXctjjz3G\n/PnzOf3001mxYsVW97HffvsxdepUzjjjDLp168bxxx/PM888w8aNG/ne977HjTfe2JnfolQz9fX1\nTJ48mVGjRrFhwwbOO+88Bg8ezLRp0wCYMGECd9xxB1OnTqW+vp699tqL6dOnExFbfS3AxIkTWbp0\nKd26dePQQw9tfr+XX36ZUaNG0a1bN3r16sUtt9zSXMu1117LOeecwzvvvMOYMWMYM2YMAKNGjeL3\nv/89gwYNoq6ujl/84hfsv//+Vf6ktlN7hjp11a9aD3OdO3dujhw5snn9yiuvzCuvvHKzPocddlge\neuiheeihh2aPHj2yZ8+eeffdd2/xXt///vdzypQpmZk5atSofPDBB5u39evXL19++eUt3n/kyJE5\nd+7cLd7r17/+dV566aW5bt263H///Zv3v+eee+bBBx+c8+fP3+HvXdLOi3YOc635L/kd+ap1QLz/\n/vvZt2/fXLFiRfM46sWLF2+1/9e+9rX83e9+17y+aTz0X/7ylzz88MPzb3/7W2ZmTp06Na+44orM\nzFy6dGn27t07N27cmIsXL86hQ4fmu+++mytWrMi+fftmU1PTZu+1du3aHDZsWC5dunSL/Z9wwgmG\ng6R2B4SnmHZAew5vt+W0005jzZo17LHHHkyZMoV9990XKI2UOO+88xgyZAjdu3fnpptuIiIYPHgw\np59+OoMGDaK+vp4pU6Y0n5b67ne/y6JFiwD40Y9+xMCBAzvxO5e0O4jMbLtXF9XQ0JCO65ekykTE\nwsxsaKufo5gkSYUMCElSIQNCklTIgJAkFapaQETE6IhYGhHLI2JiwfZPR8RrEfFE+etH1apNkrSl\nqgxzjYg6YApwIrAKmB8RMzOz9cx2D2fmP1ejJknStlXrCOJYYHlmrsjM9cB0YGyV9i1J2g7VulGu\nF7CyxfoqoGju6eMj4klgNXBJZjZWozhJtTHsX8fVuoSd1qJLpnf6PrrSndSPA30y882IOAm4BxjQ\nulNEjAfGA/Tp06e6FUrSbqRap5hWA4e0WO9dbmuWma9n5pvl5VnAHhFxQOs3yszrMrMhMxs2Pf9A\nktTxqnUEMR8YEBF9KQXDOODMlh0i4iDgpczMiDiWUnit6ayCPLTdftU4tJVUe1UJiMxsiogLgfuB\nOuCGzGyMiAnl7dOALwPfiogm4B1gXO7ME0VJ0k6uatcgyqeNZrVqm9ZieTIwuVr1SJK2zTupJUmF\nDAhJUiEDQpJUyICQJBUyICRJhQwISVIhA0KSVMiAkCQVMiAkSYUMCElSIQNCklTIgJAkFTIgJEmF\nDAhJUiEDQpJUyICQJBUyICRJhQwISVIhA0KSVMiAkCQVMiAkSYUMCElSIQNCklTIgJAkFTIgJEmF\nDAhJUiEDQpJUqGoBERGjI2JpRCyPiInb6HdMRDRFxJerVZskaUtVCYiIqAOmAGOAQcBXImLQVvpd\nBfy+GnVJkrauWkcQxwLLM3NFZq4HpgNjC/p9B7gTeLlKdUmStqJaAdELWNlifVW5rVlE9AK+CEyt\nUk2SpG3oSheprwYuz8yN2+oUEeMjYkFELHjllVeqVJok7X7q29sxInoC72Tmm+VrBWcDG4Fb2vql\nDqwGDmmx3rvc1lIDMD0iAA4AToqIpsy8p2WnzLwOuA6goaEh21u/JKky7Q4I4F5gAvAn4KfAF4D3\ngeHAf2njtfOBARHRl1IwjAPObNkhM/tuWo6IG4F7W4eDJKl6KgmIgcAT5eX/DBwPvAk00kZAZGZT\nRFwI3A/UATdkZmNETChvn1Zp4ZKkzlVJQGwAukfEQOC1zHw+IroBH2rPizNzFjCrVVthMGTmORXU\nJUnqBJUExH3A7cD+lIapQumehtbXEiRJu4BKAuIbwNcoXXe4pdx2APDfOrgmSVIX0O6AyMz3gOvK\np5U+AryQmXM6qzBJUm21+z6IiNg3Iv4f8C6wvNx2SkT8S2cVJ0mqnUpulJsGvAYcCqwvtz0KnNHR\nRUmSaq+SaxCfAz6ame9HRAJk5isRcWDnlCZJqqVKjiBeo3RRullE9AFe6NCKJEldQiUB8Rvgzoj4\nDNAtIv4JuInSqSdJ0i6mklNMVwHvUHquwx7ADcCvgUmdUJckqcYqGeaalMLAQJCk3cA2AyIiPpWZ\nfywvf3Zr/TLzwY4uTJJUW20dQVwLDCkv/++t9EmgX4dVJEnqErYZEJk5pMVy3231lSTtWiq5k3rG\nVtrv6rhyJEldRSXDXD+zlfZPd0AdkqQups1RTBHx4/Ji9xbLm/QD/tLhVUmSaq49w1w3PUu6G5s/\nVzqBlTjdtyTtktoMiMw8FyAi5mbm9Z1fkiSpK2jrPojDMvO58uoDEVE4nDUzV3R0YZKk2mrrCOLP\nwN7l5eWUTitFqz4J1HVwXZKkGmvrPoi9WyxXMuJJkrST85e+JKlQW9cgHqZ0CmmbMvNTHVaRJKlL\naOsaxG+qUoUkqctp6xrETdUqRJLUtbR1iumrmXlLefm8rfXLzBs6ujBJUm21dYrpK8At5eWvbqVP\nUnq6nCRpF9LWKaaTWixvbbK+domI0ZSeRlcH/CYzf95q+1jgJ8BGoAm4ODMf2ZF9SpK2XyXPpCYi\n9gVOBj4K/BX4t8xc147X1VF6lvWJwCpgfkTMzMwlLbo9AMzMzIyIocDtwBGV1CdJ6jiVPA/is8Bz\nwEXAMcB3gOci4nPtePmxwPLMXJGZ64HpwNiWHTLzzfJzrwF60I7htZKkzlPJEcRkYHxm3r6pISL+\nE6Ujg7b+0u9FaebXTVYBI1p3iogvAj8DDqR0pCJJqpFK7qT+KHBnq7a7gYM6qpjMvDszjwBOpXQ9\nYgsRMT4iFkTEgldeeaWjdi1JaqWSgLgFuKBV27eAm9vx2tVs/iyJ3uW2Qpn5R6BfRBxQsO26zGzI\nzIaePXu2Y9eSpO1RyVQb3YAJEXEZpV/uvYCPAI+1Yz/zgQER0bf82nHAma321R94pnyR+ihgT2BN\nBd+LJKkDVTrVxnY9MCgzmyLiQuB+SsNcb8jMxoiYUN4+DTgNODsi3gfeAc5ocdFaklRlVZtqIzNn\nAbNatU1rsXwVcFVH7U+StGMqvQ/iI5SGrB5AiwcHOdWGJO162h0QEXEq8H+Bp4HBQCMwBHgEp9qQ\npF1OJaOY/gU4NzM/DrxV/nc8sLBTKpMk1VQlAdEnM3/Xqu0m4OwOrEeS1EVUEhAvl69BQGmKjX8C\n/pHSqCRJ0i6mkoC4HvhkeflXwEPAIuDaji5KklR77b5IXR6Gumn55oiYA/TIzKc6ozBJUm1VOsy1\nDjiOv0/33Z67qCVJO6FKhrkOBe4BPkBpNtbewLsR8cXMXNRJ9UmSaqSSaxA3UJrau1dmHktpLqbJ\neA+EJO2SKgmIgcDVm+ZHKv87CRjQGYVJkmqrkoCYBZzSqu0LwL91XDmSpK6irem+b+Hv033XAdMj\nYiGlp8MdAhwNzOjUCiVJNdHWRerlrdYXt1heQmn6bknSLqit6b7/e7UKkSR1LZXeB/FpSnMv9aL0\nZLhbMvOhTqhLklRj7b5IHRHfAG4HXgTuAl4Abo2Ib3ZSbZKkGqrkCOIy4MSWN8VFxG3AnWzno0gl\nSV1XJcNc96d0YbqlpcA/dFw5kqSuopKAeAT4ZUR8ECAiegC/AOZ2RmGSpNqqJCAmAEOB1yLiJWAd\nMAw4vzMKkyTVVruuQUREAHsBnwMOojyba2au6sTaJEk11K6AyMyMiD8De5dDwWCQpF1cJaeY/kRp\nwj5J0m6gkmGuc4DZEXEjpbmYNs3RRGY65bck7WIqCYhPAM8CJ7RqT3wmhCTtctoMiPKw1v8KvAk8\nDlyZme91dmGSpNpqzzWIKZSe+/AUcBrwr9uzo4gYHRFLI2J5REws2H5WRDwZEX+OiLkRMWx79iNJ\n6hjtCYjRwMjMvAwYA/xzpTuJiDpKQTMGGAR8JSIGter2LHBCZh4J/AS4rtL9SJI6TnsCokdmvgCQ\nmSuBD2/Hfo4FlmfmisxcD0wHxrbskJlzM/Nv5dXHgN7bsR9JUgdpz0Xq+oj4DBBbWSczH2zjPXpR\nGvm0ySpgxDb6fx24rx21SZI6SXsC4mU2H6W0ptV6Av06qqBy+Hwd+ORWto8HxgP06dOno3YrSWql\nzYDIzMM6YD+rKT3DepPe5bbNRMRQ4DfAmMxcs5V6rqN8faKhoSGL+kiSdlwld1LviPnAgIjoGxHd\ngXHAzJYdIqIPpQcRfTUzl1WpLknSVlT0yNHtlZlNEXEhcD9QB9yQmY0RMaG8fRrwI0rPnLi2NDcg\nTZnZUI36JElbqkpAAGTmLGBWq7ZpLZa/AXyjWvVIkratWqeYJEk7GQNCklTIgJAkFTIgJEmFDAhJ\nUiEDQpJUyICQJBUyICRJhQwISVIhA0KSVMiAkCQVMiAkSYUMCElSIQNCklTIgJAkFTIgJEmFDAhJ\nUiEDQpJUyICQJBUyICRJhQwISVIhA0KSVMiAkCQVMiAkSYUMCElSIQNCklTIgJAkFapaQETE6IhY\nGhHLI2JiwfYjIuLRiHgvIi6pVl2SpGL11dhJRNQBU4ATgVXA/IiYmZlLWnRbC1wEnFqNmiRJ21at\nI4hjgeWZuSIz1wPTgbEtO2Tmy5k5H3i/SjVJkrahWgHRC1jZYn1VuU2S1EXtdBepI2J8RCyIiAWv\nvPJKrcuRpF1WtQJiNXBIi/Xe5baKZeZ1mdmQmQ09e/bskOIkSVuqVkDMBwZERN+I6A6MA2ZWad+S\npO1QlVFMmdkUERcC9wN1wA2Z2RgRE8rbp0XEQcACYB9gY0RcDAzKzNerUaMkaXNVCQiAzJwFzGrV\nNq3F8ouUTj1JkrqAne4itSSpOgwISVIhA0KSVMiAkCQVMiAkSYUMCElSIQNCklTIgJAkFTIgJEmF\nDAhJUiEDQpJUyICQJBUyICRJhQwISVIhA0KSVMiAkCQVMiAkSYUMCElSIQNCklTIgJAkFTIgJEmF\nDAhJUiEDQpJUyICQJBUyICRJhQwISVIhA0KSVKhqARERoyNiaUQsj4iJBdsjIv5XefuTEXFUtWqT\nJG2pKgEREXXAFGAMMAj4SkQMatVtDDCg/DUemFqN2iRJxap1BHEssDwzV2TmemA6MLZVn7HAzVny\nGLBvRBxcpfokSa1UKyB6AStbrK8qt1XaR5JUJfW1LqBSETGe0ikogDcjYmkt6+lEBwCv1rqIInHp\nbbUuQaqGLvszCDv8c3hoezpVKyBWA4e0WO9dbqu0D5l5HXBdRxfY1UTEgsxsqHUd0u7Kn8HqnWKa\nDwyIiL4R0R0YB8xs1WcmcHZ5NNNxwGuZ+UKV6pMktVKVI4jMbIqIC4H7gTrghsxsjIgJ5e3TgFnA\nScBy4G3g3GrUJkkqFplZ6xpUICLGl0+nSaoBfwYNCEnSVjjVhiSpkAEhSSpkQEiSChkQXURERMt/\nJanWDIguIjMzIvallBH7lCc4lKSacRRTFxARHwfOAM4G3gX+ndLNhY9k5lO1rE3S7suA6AIi4lHg\nSUpTiBxEaerzoyjdyDgtM2+IiEj/Y0mdJiL+AXgjM9+vdS1dhQFRYxHRk9Ld4/tl5sYW7XsDXwN+\nAFyUmXfUqERpl1f+ObyX0pQ/fwCWAa+3+pnskZlv1ajEmvAaRO1tAB6hFAbNMvONzJwM/AQ4KyL2\nrEVx0m7iHKA/cCJwJ3ArcH5EDI6IvSJiD2Bx+Shjt7HTTfe9q8nMtRHx78APImIIpb9iHs/M18pd\n3gD6ZuZ7NStS2vUNAa7OzJ9ERD/gPODbwKXAA0AA3TJzbQ1rrDpPMXUREXEupesO3SkdVbxPKcAb\ngBsz00ewSp0kIv4ROCwzH2jV/ingi8B3ga9n5v+pRX21YkDUUEQMBM4HNh229gTeAZ6jFBJHAv8T\nmNPyXKikzhMR3Sj9btzQom0DsHdmvl27yqrPU0y1NQN4mNJTq/4GrAP6UAqKX2bmkzWsTdqdtbw4\n/SVg9u4WDuARRM1ExChgSmb2L6/XAx+ldErpC5SC4quZ+dfaVSnt2iLiGOBi4EHgPzJzeYttzUPL\nI6Ku5RHF7sJRTLXTA3gpIg6B0kOVMvP5zLwL+CGlU0yjalmgtBv4PqU/yj4D/I+I+GVEfDkiDi7P\nbnBgRPx6dwwH8AiiZspzLt1B6Ql738vMFa22XwvUZeb5tahP2tWVp7O5D7gNWAocDXwMOBBoAh6l\ndIH61cz8Uq3qrCWvQdRI+a+TH1C6CP2niHiSUmA8CJwAnAJ8uYYlSru67sBNwIrMfBR4JCIOAj5O\naUThx4BPAsfUrsTa8giiC4iIo4CxwJeAgymFxOzMvKGmhUm7gYjolpkbW09nExHjgZ9l5v41LK+m\nDIguJiL2Arq3uFFOUhVtCoqI+Amlm+N+WOuaasWAkKQCEXEA8FZmvlPrWmrFgJAkFXKYqySpkAEh\nSSpkQEiSChkQkqRCBoQkqZABIUkq9P8BC8avJRwHJswAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "<matplotlib.figure.Figure at 0x11487b208>"
       ]
      },
      "metadata": {},
@@ -489,17 +416,39 @@
     }
    ],
    "source": [
-    "%run \"../version.ipynb\""
+    "run_ibmqx2 = Q_program.execute([\"bell\"], backend=\"local_qasm_simulator\", coupling_map=ibmqx2_coupling)\n",
+    "plot_histogram(run_ibmqx2.get_counts(\"bell\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAEFCAYAAAD5bXAgAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAGiFJREFUeJzt3X2YlXW97/H3F0Y6omYF+DQje3D7cAQFxcGHc0wlM4Ta\naKaGbh8xEU7uTuXD8bRrZ9mD2lbbWyViJ1nYiXYmweUmtXRjcokBmqloKgIqqFsx0wRRBr/nj7WY\nhuGGmSUzaw3wfl0Xl/f63b97re/Ca+bDff/u3++OzESSpLZ61LoASVL3ZEBIkgoZEJKkQgaEJKmQ\nASFJKmRASJIKGRCSpEIGhCSpkAEhSSpkQEiSCtXVuoDN0bdv32xsbKx1GZK0RXnwwQdXZGa/9vpt\n0QHR2NjIggULal2GJG1RIuLZjvSr2iWmiDg+Ip6MiEURcdlG+hwTEQ9HxMKIuLdatUmSNlSVM4iI\n6AncCBwHLAPmR8TMzHy8VZ8PABOB4zPzuYjYpRq1SZKKVesM4lBgUWYuzsx3gGnACW36nA7clpnP\nAWTmy1WqTZJUoFoBUQ883+r1snJba/sCH4yI2RHxYEScVaXaJEkFutMgdR1wCHAssD0wNyIeyMyn\nWneKiHHAOID+/ftXvUhJ2lZU6wxiObBnq9cN5bbWlgF3ZubKzFwB/BYY0vaNMnNyZjZlZlO/fu3e\npSVJeo+qFRDzgX0iYkBE9ALGADPb9JkBHBkRdRHRGzgMeKJK9UmS2qjKJabMbI6IC4E7gZ7AlMxc\nGBHjy/snZeYTEXEH8AjwLvCDzHysGvVJkjYUmVnrGt6zpqamdKKcJFUmIh7MzKb2+rkWkySpkAEh\nSSpkQEiSChkQkqRCBoQkqZABIUkqZEBI2qLdcccd7Lfffuy9995ceeWVG+yfPXs2O++8MwcddBAH\nHXQQX//611v2jR07ll122YUDDjig8L2vueYaIoIVK1a0tD3yyCMcccQRDBo0iAMPPJDVq1evd8zo\n0aPXe7/nnnuO4cOHc/DBBzN48GBmzZq1uV+5arrTWkySVJG1a9fy2c9+ll//+tc0NDQwbNgwRo8e\nzcCBA9fr9+EPf5jbb799g+PPOeccLrzwQs46a8O1QZ9//nnuuuuu9dZ8a25u5owzzmDq1KkMGTKE\nV199le22265l/2233caOO+643vt84xvf4NRTT2XChAk8/vjjjBo1iqVLl27mN68OzyAkbbHmzZvH\n3nvvzV577UWvXr0YM2YMM2bM6PDxRx11FB/60IcK933hC1/g6quvJiJa2u666y4GDx7MkCGlZeL6\n9OlDz549AXjzzTe59tpr+fKXv7ze+0QEb7zxBgCvv/46e+yxR0XfsZYMCElbrOXLl7Pnnn9dB7Sh\noYHly9uuAwr3338/gwcPZuTIkSxcuLDd950xYwb19fUtQbDOU089RUQwYsQIhg4dytVXX92y7ytf\n+QoXXXQRvXv3Xu+Yyy+/nFtuuYWGhgZGjRrF9ddfX+nXrBkvMUnaqg0dOpTnnnuOHXfckVmzZnHi\niSfy9NNPb7T/qlWr+Na3vsVdd921wb7m5mbmzJnD/Pnz6d27N8ceeyyHHHIIffr04ZlnnuG6667b\n4PLRT3/6U8455xwuuugi5s6dy5lnnsljjz1Gjx7d/9/n3b9CSdqI+vp6nn/+r88iW7ZsGfX16z+L\n7P3vf3/LuMCoUaNYs2bNeoPObT3zzDMsWbKEIUOG0NjYyLJlyxg6dCgvvfQSDQ0NHHXUUfTt25fe\nvXszatQoHnroIebOncuCBQtobGzkyCOP5KmnnuKYY44B4KabbuLUU08F4IgjjmD16tWb/PzuxICQ\ntMUaNmwYTz/9NEuWLOGdd95h2rRpjB49er0+L730EusWJZ03bx7vvvsuffr02eh7Hnjggbz88sss\nXbqUpUuX0tDQwEMPPcRuu+3GiBEjePTRR1m1ahXNzc3ce++9DBw4kAkTJvDCCy+wdOlS5syZw777\n7svs2bOB0oPN7r77bgCeeOIJVq9ezZbyLBsvMUnaYtXV1XHDDTcwYsQI1q5dy9ixYxk0aBCTJk0C\nYPz48dx6661873vfo66uju23355p06a1DDyfdtppzJ49mxUrVtDQ0MDXvvY1zjvvvI1+3gc/+EG+\n+MUvMmzYMCKCUaNG8fGPf3yTNV5zzTWcf/75XHfddUQEN99883oD392Zy31L0jbG5b4lSZvFgJAk\nFTIgNlN70/zXmT9/PnV1ddx6660tbddddx2DBg3igAMO4LTTTmuZsn/55ZdTX1/fsjTAuqn58+bN\na2kbMmQI06dPb3mvY445hv32269l/8svvwzAtddey8CBAxk8eDDHHnsszz77bFf8NUjaGmXmFvvn\nkEMOyVpqbm7OvfbaK5955pl8++23c/Dgwblw4cLCfsOHD8+RI0fmz3/+88zMXLZsWTY2NuaqVasy\nM/OUU07JH/7wh5mZ+dWvfjW/853vbPA+K1euzDVr1mRm5gsvvJD9+vVreX300Ufn/PnzNzjmnnvu\nyZUrV2Zm5sSJE/PUU0/d/C8uaYsGLMgO/I71DGIzdHSa//XXX8+nPvUpdtlll/Xam5ubeeutt2hu\nbmbVqlXtTsHv3bs3dXWlG89Wr17doTshhg8f3jKz8/DDD2fZsmUd/XqStnEGxGboyDT/5cuXM336\ndCZMmLBee319PRdffDH9+/dn9913Z+edd+ZjH/tYy/7rr7+ewYMHM3bsWF577bWW9t/97nctq0hO\nmjSpJTAAzj77bA466CCuuOKKlvu+W7vpppsYOXLkZn9vSdsGA6KLff7zn+eqq67aYFr9a6+9xowZ\nM1iyZAkvvPACK1eu5JZbbgFgwoQJLF68mIcffpjdd9+diy66qOW4ww47jIULFzJ//ny+/e1vt4xb\n/OQnP2HhwoXcd9993HfffUydOnW9z7vllltYsGABl1xySRd/Y0lbCyfKbYaOTPNfsGABY8aMAWDF\nihXMmjWLuro61qxZw4ABA1pmVJ500kncf//9nHHGGey6664tx59//vl84hOf2OCz999/f3bccUce\ne+wxmpqaWj53p5124vTTT2fevHktSxj/5je/4Zvf/Cb33nsv73vf+zr3L0HSVssziM3QkWn+S5Ys\naZmyf/LJJzNx4kROPPFE+vfvzwMPPMCqVavITO6++272339/AF588cWW46dPn97y8JElS5bQ3NwM\nwLPPPssf//hHGhsbaW5ublnbZc2aNdx+++0tx/z+97/nggsuYObMmRuMgUjSpngGsRk6Ms1/Yw47\n7DBOPvlkhg4dSl1dHQcffDDjxo0D4NJLL+Xhhx8mImhsbOT73/8+AHPmzOHKK69ku+22o0ePHkyc\nOJG+ffuycuVKRowYwZo1a1i7di0f/ehHOf/88wG45JJLePPNNznllFOA0rowM2fO7Mq/FklbCZfa\nkFQzQ/55TK1L2GL94eJp7/nYbrfURkQcHxFPRsSiiLisYP8xEfF6RDxc/vNP1apNkrShqlxiioie\nwI3AccAyYH5EzMzMx9t0vS8zNxyRlSRVXbXOIA4FFmXm4sx8B5gGnFClz5YkvQfVCoh64PlWr5eV\n29r6HxHxSET8KiIGVac0SVKR7nQX00NA/8x8MyJGAb8E9mnbKSLGAeOgdEeOJKlrVOsMYjmwZ6vX\nDeW2Fpn5Rma+Wd6eBWwXEX3bvlFmTs7Mpsxs2lIe2ydJW6JqBcR8YJ+IGBARvYAxwHo340fEblFe\nfS4iDi3X9mqV6pMktVGVS0yZ2RwRFwJ3Aj2BKZm5MCLGl/dPAk4GJkREM/AWMCa35EkakrSFq9oY\nRPmy0aw2bZNabd8A3FCteiRJm9adBqmryhmc793mzOCUtOVwsT5JUiEDQpJUyICQJBUyICRJhQwI\nSVIhA0KSVMiAkCQVMiAkSYUMCElSIQNCklTIgJAkFTIgJEmFDAhJUiEDQpJUyICQJBUyICRJhQwI\nSVIhA0KSVMiAkCQVMiAkSYUMCElSIQNCklTIgJAkFTIgJEmFDAhJUqGqBUREHB8RT0bEooi4bBP9\nhkVEc0ScXK3aJEkbqkpARERP4EZgJDAQOC0iBm6k31XAXdWoS5K0cR0OiIjoFxE7lrd7RsS5EXF2\nRHTkPQ4FFmXm4sx8B5gGnFDQ7x+AXwAvd7QuSVLXqOQM4nZgn/L2N4GLgS8A13Tg2Hrg+Vavl5Xb\nWkREPfBJ4HsV1CRJ6iKVBMS+wMPl7TMoXS76CDCmk2r5LvB/MvPdTXWKiHERsSAiFrzyyiud9NGS\npLbqKui7FugVEfsCr2fmc+XLSzt24NjlwJ6tXjeU21prAqZFBEBfYFRENGfmL1t3yszJwGSApqam\nrKB+SVIFKgmIXwH/DvShNIYApQHntr/oi8wH9omIAeX+Y4DTW3fIzAHrtiPiZuD2tuEgSaqeSgLi\nM8DZwBpgarmtL3B5ewdmZnNEXAjcCfQEpmTmwogYX94/qZKiJUldr8MBkZlvA5PLl5V2BV7MzNkV\nHD8LmNWmrTAYMvOcjr6vJKlrVHKb6wci4v8Bq4FF5bbREfGNripOklQ7ldzFNAl4Hfgb4J1y21zg\n051dlCSp9ioZgzgW2CMz10REAmTmKxGxS9eUJkmqpUrOIF6nNCjdIiL6Ay92akWSpG6hkoD4AfCL\niBgO9IiII4AfUbr0JEnaylRyiekq4C1Ki+5tB0wBvg/8SxfUJUmqsUpuc01KYWAgSNI2YJMBERFH\nZeZvy9sf2Vi/zLynswuTJNVWe2cQE4EDyts3baRPAnt1WkWSpG5hkwGRmQe02h6wqb6SpK1LJTOp\nZ2yk/bbOK0eS1F1Ucpvr8I20H9MJdUiSupl272KKiK+XN3u12l5nL+DZTq9KklRzHbnNdd2Dfnqw\n/kN/ktJjRC/v5JokSd1AuwGRmecCRMT9mflvXV+SJKk7aG8eRGNmLi2/vDsiCm9nzczFnV2YJKm2\n2juDeBTYqby9iNJlpWjTJyk9JU6StBVpbx7ETq22K7njSZK0hfOXviSpUHtjEPdRuoS0SZl5VKdV\nJEnqFtobg/hBVaqQJHU77Y1B/KhahUiSupf2LjGdmZlTy9tjN9YvM6d0dmGSpNpq7xLTacDU8vaZ\nG+mTlJ4uJ0nairR3iWlUq+2NLdYnSdoKVfJMaiLiA8DHgT2AF4D/yMw/d0VhkqTaquR5EB8BlgKf\nA4YB/wAsjYhju6Y0SVItVTJR7gZgXGYelpmnZubhwPnAjR05OCKOj4gnI2JRRFxWsP+EiHgkIh6O\niAURcWQFtUmSOlklAbEH8Is2bdOB3do7MCJ6UgqSkcBA4LSIGNim293AkMw8CBiLczAkqaYqCYip\nwGfbtE0AftyBYw8FFmXm4sx8B5gGnNC6Q2a+mZnrZm3vQAdmcEuSuk4lS230AMZHxKXAcqAe2BV4\noAOfU0/p4ULrLAMOK/i8TwLfBnahNBheVNM4YBxA//79O/DRkqT3otKlNrr0gUGZOR2YHhFHAVcA\nHy3oMxmYDNDU1ORZhiR1kWottbGc9R9X2lBu29jn/jYi9oqIvpm5opNqkCRVoNJ5ELtSGk/oS6sH\nB3VgqY35wD4RMYBSMIwBTm/z3nsDz2RmRsRQ4H3Aq5XUJ0nqPB0OiIg4EbgFeBoYBCwEDgDm0M5S\nG5nZHBEXAndSevrclMxcGBHjy/snAZ8CzoqINcBbwKdbDVpLkqqskjOIbwDnZubPI+K1zDw4Is6l\nFBbtysxZwKw2bZNabV8FXFVBPZKkLlTJba79M/Pnbdp+BJzVifVIkrqJSgLi5fIYBJSW2DgC+FtK\nl4wkSVuZSgLi34B1y19cB/wn8AdgYmcXJUmqvQ6PQZTHCNZt/zgiZgM7ZOYTXVGYJKm2Kr3NtSdw\nOH9d7rsjs6glSVugSm5zHQz8EvhvlJbKaABWR8QnM/MPXVSfJKlGKhmDmEJpRdb6zDyU0vpKN+Dj\nRiVpq1RJQOwLfHfd5LXyf/8F2KcrCpMk1VYlATELGN2m7e+A/+i8ciRJ3UV7y31P5a/LffcEpkXE\ng5SW7t4TOASY0aUVSpJqor1B6kVtXj/WavtxSmsrSZK2Qu0t9/21ahUiSepeKp0HcQyltZfqKS3b\nPTUz/7ML6pIk1ViHB6kj4jPAvwMvAbcBLwI/jYjzu6g2SVINVXIGcSlwXOtJcRHxM+AXdPGjSCVJ\n1VfJba59KA1Mt/Yk8KHOK0eS1F1UEhBzgGsjojdAROwAfAe4vysKkyTVViUBMR4YDLweEf8F/BkY\nAlzQFYVJkmqrQ2MQERHA9sCxwG6UV3PNzGVdWJskqYY6FBCZmRHxKLBTORQMBknaylVyien3lBbs\nkyRtAyq5zXU2cEdE3ExpLaZ1azSRmS75LUlbmUoC4n8CS4Cj27QnPhNCkrY67QZE+bbWLwNvAg8B\n38rMt7u6MElSbXVkDOJGSs99eAL4FPDPXVqRJKlb6EhAHA98LDMvBUYCn+jakiRJ3UFHAmKHzHwR\nIDOfB3Z+Lx8UEcdHxJMRsSgiLivY//cR8UhEPBoR90fEkPfyOZKkztGRQeq6iBgOxEZek5n3bOoN\nIqInpUtVx1GaQzE/ImZmZuu1nZYAR2fmaxExEpgMHNbxryJJ6kwdCYiXWf8upVfbvE5gr3be41Bg\nUWYuBoiIacAJtFr8LzNbr+n0ANDQgdokSV2k3YDIzMZO+Jx6SnMn1lnGps8OzgN+1QmfK0l6jyp6\nolw1lC9fnQccuZH944BxAP37969iZZK0balkqY3NsRzYs9XrhnLbeiJiMPAD4ITMfLXojTJzcmY2\nZWZTv379uqRYSVL1AmI+sE9EDIiIXsAYYGbrDhHRn9KjTM/MzKeqVJckaSOqcokpM5sj4kLgTqAn\nMCUzF0bE+PL+ScA/UXpq3cTS6uI0Z2ZTNeqTJG2oamMQmTkLmNWmbVKr7c8An6lWPZKkTavWJSZJ\n0hbGgJAkFTIgJEmFDAhJUiEDQpJUyICQJBUyICRJhQwISVIhA0KSVMiAkCQVMiAkSYUMCElSIQNC\nklTIgJAkFTIgJEmFDAhJUiEDQpJUyICQJBUyICRJhQwISVIhA0KSVMiAkCQVMiAkSYUMCElSIQNC\nklTIgJAkFapaQETE8RHxZEQsiojLCvb/94iYGxFvR8TF1apLklSsrhofEhE9gRuB44BlwPyImJmZ\nj7fq9ifgc8CJ1ahJkrRp1TqDOBRYlJmLM/MdYBpwQusOmflyZs4H1lSpJknSJlQrIOqB51u9XlZu\nkyR1U1vcIHVEjIuIBRGx4JVXXql1OZK01apWQCwH9mz1uqHcVrHMnJyZTZnZ1K9fv04pTpK0oWoF\nxHxgn4gYEBG9gDHAzCp9tiTpPajKXUyZ2RwRFwJ3Aj2BKZm5MCLGl/dPiojdgAXA+4F3I+LzwMDM\nfKMaNUqS1leVgADIzFnArDZtk1ptv0Tp0pMkqRvY4gapJUnVYUBIkgoZEJKkQgaEJKmQASFJKmRA\nSJIKGRCSpEIGhCSpkAEhSSpkQEiSChkQkqRCBoQkqZABIUkqZEBIkgoZEJKkQgaEJKmQASFJKmRA\nSJIKGRCSpEIGhCSpkAEhSSpkQEiSChkQkqRCBoQkqZABIUkqZEBIkgpVLSAi4viIeDIiFkXEZQX7\nIyL+tbz/kYgYWq3aJEkbqkpARERP4EZgJDAQOC0iBrbpNhLYp/xnHPC9atQmSSpWrTOIQ4FFmbk4\nM98BpgEntOlzAvDjLHkA+EBE7F6l+iRJbVQrIOqB51u9XlZuq7SPJKlK6mpdQKUiYhylS1AAb0bE\nk7Wspwv1BVbUuogiccnPal2CVA3d9mcQNvvn8G860qlaAbEc2LPV64ZyW6V9yMzJwOTOLrC7iYgF\nmdlU6zqkbZU/g9W7xDQf2CciBkREL2AMMLNNn5nAWeW7mQ4HXs/MF6tUnySpjaqcQWRmc0RcCNwJ\n9ASmZObCiBhf3j8JmAWMAhYBq4Bzq1GbJKlYZGata1CBiBhXvpwmqQb8GTQgJEkb4VIbkqRCBoQk\nqZABIUkqZEB0ExERrf8rSbVmQHQTmZkR8QFKGfH+8gKHklQz3sXUDUTEwcCngbOA1cBvKE0unJOZ\nT9SyNknbLgOiG4iIucAjlJYQ2Y3S0udDKU1knJSZUyIi0v9ZUpeJiA8Bf8nMNbWupbswIGosIvpR\nmj3+wcx8t1X7TsDZwJeAz2XmrTUqUdrqlX8Ob6e05M+vgaeAN9r8TO6QmStrVGJNOAZRe2uBOZTC\noEVm/iUzbwCuAP4+It5Xi+KkbcQ5wN7AccAvgJ8CF0TEoIjYPiK2Ax4rn2VsM7a45b63Npn5p4j4\nDfCliDiA0r9iHsrM18td/gIMyMy3a1aktPU7APhuZl4REXsBY4H/BVwC3A0E0CMz/1TDGqvOS0zd\nREScS2ncoRels4o1lAK8Cbg5M30Eq9RFIuJvgcbMvLtN+1HAJ4H/DZyXmT+sRX21YkDUUETsC1wA\nrDtt7Qe8BSylFBIHAtcAs1tfC5XUdSKiB6XfjWtbta0FdsrMVbWrrPq8xFRbM4D7KD216jXgz0B/\nSkFxbWY+UsPapG1Z68Hpk4A7trVwAM8gaiYiRgA3Zube5dd1wB6ULin9HaWgODMzX6hdldLWLSKG\nAZ8H7gHuzcxFrfa13FoeET1bn1FsK7yLqXZ2AP4rIvaE0kOVMvO5zLwN+EdKl5hG1LJAaRvwfyn9\no2w4cHVEXBsRJ0fE7uXVDXaJiO9vi+EAnkHUTHnNpVspPWHvi5m5uM3+iUDPzLygFvVJW7vycja/\nAn4GPAkcAuwP7AI0A3MpDVCvyMyTalVnLTkGUSPlf518idIg9O8j4hFKgXEPcDQwGji5hiVKW7te\nwI+AxZk5F5gTEbsBB1O6o3B/4EhgWO1KrC3PILqBiBgKnACcBOxOKSTuyMwpNS1M2gZERI/MfLft\ncjYRMQ74dmb2qWF5NWVAdDMRsT3Qq9VEOUlVtC4oIuIKSpPj/rHWNdWKASFJBSKiL7AyM9+qdS21\nYkBIkgp5m6skqZABIUkqZEBIkgoZEJKkQgaEJKmQASFJKvT/AYAKXQ3wy+lAAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x1145d0f60>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "run_ibmqx4 = Q_program.execute([\"bell\"], backend=\"local_qasm_simulator\", coupling_map=ibmqx4_coupling)\n",
+    "plot_histogram(run_ibmqx4.get_counts(\"bell\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "#%run \"../version.ipynb\""
+   ]
   }
  ],
  "metadata": {
@@ -519,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I've added a simple compiling and running example to the backend tutorial. It does not replace compiling_and_running.ipynb in the appendix, but references that as a more complicated example. 